### PR TITLE
Fixed the azure deploy button link for update recipes

### DIFF
--- a/cosmos/sql/tools/java/ycsb/recipes/update/10-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/10-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2main%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F10-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F10-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/10-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/10-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F10-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2main%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F10-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/100-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/100-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F100-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F100-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/20-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/20-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F20-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F20-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/30-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/30-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F30-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F30-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/50-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/50-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F50-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F50-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided

--- a/cosmos/sql/tools/java/ycsb/recipes/update/500-thousand-rps-update/README.md
+++ b/cosmos/sql/tools/java/ycsb/recipes/update/500-thousand-rps-update/README.md
@@ -40,7 +40,7 @@ This recipe encapsulates a update only workload with a maximum requests per seco
    
  [More details about the parameters](../../#basic-configuration)
  
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fusers%2Fratella%2Fupdate-recipes%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F500-thousand-rps-update%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-db-benchmarking%2Fmain%2Fcosmos%2Fsql%2Ftools%2Fjava%2Fycsb%2Frecipes%2Fupdate%2F500-thousand-rps-update%2Fazuredeploy.json)
 
 ## Output
 The job status and results will be available in the following locations in the storage account provided


### PR DESCRIPTION
Was made aware of the azure deploy button not opening the template in azure portal.
The issue was fixed up changing the branch name in the azure deploy button link. 