### PR TITLE
Added storage accessibility check on master node

### DIFF
--- a/cosmos/scripts/custom-script.sh
+++ b/cosmos/scripts/custom-script.sh
@@ -93,7 +93,11 @@ if [ $MACHINE_INDEX -eq 1 ]; then
     job_start_time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') # date in ISO 8601 format
   fi
 
-  az storage entity insert --entity PartitionKey="ycsb_sql" RowKey="${GUID}" JobStartTime=$job_start_time JobFinishTime="" JobStatus="Started" NoOfClientsCompleted=0 NoOfClientsStarted=1 SAS_URL=$result_storage_url --table-name "${benchmarkname}Metadata" --connection-string $RESULT_STORAGE_CONNECTION_STRING
+  latest_table_entry=$(az storage entity insert --entity PartitionKey="ycsb_sql" RowKey="${GUID}" JobStartTime=$job_start_time JobFinishTime="" JobStatus="Started" NoOfClientsCompleted=0 NoOfClientsStarted=1 SAS_URL=$result_storage_url --table-name "${benchmarkname}Metadata" --connection-string $RESULT_STORAGE_CONNECTION_STRING)
+  if [ -z "$latest_table_entry" ]; then
+    echo "Error while accessing storage account, exiting from this machine"
+    exit 1
+  fi
 else
   for i in $(seq 1 10); do
     latest_table_entry=$(az storage entity show --table-name "${benchmarkname}Metadata" --connection-string $RESULT_STORAGE_CONNECTION_STRING --partition-key "ycsb_sql" --row-key "${GUID}")


### PR DESCRIPTION
**Problem** - If we pass incorrect credentials for  azure blob storage , the master node will silently keep on running without having track of Metrics. However server nodes fail and exit the script when they are unable to find a metadata table entry which is supposed to be created by the master.

**Desired behavior**  - Both master and server node should fail early and not run any benchmarking if storage credential is incorrect.

**This PR** - It added the check on master for early detection of inaccessibility of storage and exit the script

