### PR TITLE
Make resultsStorageConnectionString a securestring

### DIFF
--- a/cosmos/infra/azuredeploy.json
+++ b/cosmos/infra/azuredeploy.json
@@ -66,7 +66,7 @@
         },
 
         "resultsStorageConnectionString": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Specifies a connection string of the storage account where results will be available."
             }

--- a/cosmos/infra/azuredeploy_mongo.json
+++ b/cosmos/infra/azuredeploy_mongo.json
@@ -66,7 +66,7 @@
         },
 
         "resultsStorageConnectionString": {
-            "type": "string",
+            "type": "securestring",
             "metadata": {
                 "description": "Specifies a connection string of the storage account where results will be avaialble"
             }


### PR DESCRIPTION
This value contains DB connection secrets and should be stored securely. This is already the case for most templates, but these two were using plain strings.